### PR TITLE
Updated `.gitignore` and `.goreleaser.yaml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ waybar-weather
 
 # Temporary files
 tmp/
+
+# Distribution files
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,7 @@ builds:
       - amd64
     goamd64:
       - v1
-    main: app
+    main: .
     binary: waybar-weather
     ldflags:
       - -w -s -extldflags "-static"
@@ -50,9 +50,6 @@ universal_binaries:
   - replace: false
 
 report_sizes: true
-
-sboms:
-  - artifacts: archive
 
 github_urls:
 


### PR DESCRIPTION
- Added `dist/` to `.gitignore` to exclude distribution files
- Updated GoReleaser `main` path to use the current directory
- Removed unused SBOMs configuration from `.goreleaser.yaml`