### PR TITLE
Add `is_day` metric and refine daylight check logic

### DIFF
--- a/service.go
+++ b/service.go
@@ -225,7 +225,7 @@ func (s *Service) fillDisplayData(target *DisplayData) {
 		target.SunriseTime, target.SunsetTime = sunrise.SunriseSunset(s.weather.Latitude, s.weather.Longitude,
 			fcastTime.Year(), fcastTime.Month(), fcastTime.Day())
 		target.IsDaytime = false
-		if fcastTime.After(target.SunriseTime) && fcastTime.Before(target.SunsetTime) {
+		if s.weather.HourlyUnits["is_day"] == "1" {
 			target.IsDaytime = true
 		}
 

--- a/weather.go
+++ b/weather.go
@@ -85,8 +85,10 @@ func (s *Service) fetchWeather(ctx context.Context) {
 	}
 
 	opts := &omgo.Options{
-		Timezone:      "auto",
-		HourlyMetrics: []string{"temperature_2m", "weather_code", "wind_speed_10m", "wind_direction_10m"},
+		Timezone: "auto",
+		HourlyMetrics: []string{
+			"temperature_2m", "weather_code", "wind_speed_10m", "is_day", "wind_direction_10m",
+		},
 	}
 	switch s.config.Units {
 	case "metric":


### PR DESCRIPTION
- Included `is_day` in hourly metrics for weather API calls.
- Updated daylight determination logic using `is_day` metric.