### PR TITLE
Add configurable intervals for weather updates and output

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ type config struct {
 	Intervals struct {
 		WeatherUpdate time.Duration `fig:"weather_update" default:"15m"`
 		Output        time.Duration `fig:"output" default:"30s"`
-	}
+	} `fig:"intervals"`
 }
 
 func newConfigFromFile(path, file string) (*config, error) {

--- a/etc/waybar-weather.toml
+++ b/etc/waybar-weather.toml
@@ -33,3 +33,19 @@ weather_mode = "forecast"
 #
 # Default: 3 hours
 forecast_hours = 5
+
+[intervals]
+## Weather update intervale
+# The interval in which the Open-Meteo API is checked for weather updates
+# If a geo location change is detected by Geoclue, a weather is triggered automatically
+#
+# Default: 15m
+weather_update = "30m"
+
+## Output interval
+# The interval in which waybar-weather outputs the JSON with the current information to
+# Waybar. If a geo location change is detected by Geoclue, a weather is triggered
+# automatically.
+#
+# Default: 30s
+output = "15s"

--- a/service.go
+++ b/service.go
@@ -96,7 +96,7 @@ func New(config *config, log *logger) (*Service, error) {
 
 func (s *Service) Run(ctx context.Context) error {
 	// Start scheduled jobs
-	_, err := s.scheduler.NewJob(gocron.DurationJob(s.config.Intervals.WeatherUpdate),
+	_, err := s.scheduler.NewJob(gocron.DurationJob(s.config.Intervals.Output),
 		gocron.NewTask(s.printWeather),
 		gocron.WithContext(ctx),
 		gocron.WithSingletonMode(gocron.LimitModeReschedule),
@@ -106,7 +106,7 @@ func (s *Service) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to create weather data output job: %w", err)
 	}
 
-	_, err = s.scheduler.NewJob(gocron.DurationJob(s.config.Intervals.Output),
+	_, err = s.scheduler.NewJob(gocron.DurationJob(s.config.Intervals.WeatherUpdate),
 		gocron.NewTask(s.fetchWeather),
 		gocron.WithContext(ctx),
 		gocron.WithSingletonMode(gocron.LimitModeReschedule),


### PR DESCRIPTION
- Introduced `Intervals` struct in `config` to manage customizable `weather_update` and `output` durations.
- Removed hardcoded intervals from `service.go` and replaced them with values from the configuration.
- Updated `intervals` configuration with new default values.