### PR TITLE
Updated `DefaultTooltipTpl` to remove duplicate `ConditionIcon` entry

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ const (
 	configEnv         = "WAYBARWEATHER"
 	DefaultTextTpl    = "{{.Current.ConditionIcon}} {{.Current.Temperature}}{{.TempUnit}}"
 	DefaultTooltipTpl = "{{.Address.City}}, {{.Address.Country}}\n" +
-		"{{.Current.Condition}} {{.Current.ConditionIcon}}\n" +
+		"{{.Current.Condition}}\n" +
 		"Feels like: {{.Current.ApparentTemperature}}{{.TempUnit}}\n" +
 		"Humidity: {{.Current.Humidity}}%\n" +
 		"Pressure: {{.Current.PressureMSL}} {{.PressureUnit}}\n" +


### PR DESCRIPTION
- Simplified `DefaultTooltipTpl` by removing redundant `ConditionIcon` usage.
- Ensured cleaner and more concise weather tooltip formatting.