### PR TITLE
Updated weather service options to include past days filter

### DIFF
--- a/internal/service/weather.go
+++ b/internal/service/weather.go
@@ -24,6 +24,7 @@ func (s *Service) fetchWeather(ctx context.Context) {
 	}
 
 	opts := &omgo.Options{
+		PastDays: 1,
 		Timezone: "auto",
 		HourlyMetrics: []string{
 			"temperature_2m", "apparent_temperature", "weather_code", "wind_speed_10m", "is_day",


### PR DESCRIPTION
This PR adds to the index lookup issue that was fixed in #33. When at the brim of a new day in a TZ close to UTC, the UTC-based data might not be available. By fetching also the data from 1 day past, this can be compensated.

- Added `PastDays` parameter to `omgo.Options` for to retrieve past day data.