### PR TITLE
Prevent publishing results with zero accuracy

### DIFF
--- a/internal/geobus/geobus.go
+++ b/internal/geobus/geobus.go
@@ -146,6 +146,9 @@ func (b *GeoBus) SubscribeAll(buffer int) (<-chan Result, func()) {
 }
 
 func (b *GeoBus) Publish(r Result) {
+	if r.AccuracyMeters == 0 {
+		return
+	}
 	if r.At.IsZero() {
 		r.At = time.Now()
 	}


### PR DESCRIPTION
- Added a check in `GeoBus.Publish` to ignore results where `AccuracyMeters` is zero.
- Ensures only meaningful and accurate data is published.