### PR TITLE
Removed leftover debug print statement in `NewFromFile` function

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,7 +66,6 @@ type Config struct {
 }
 
 func NewFromFile(path, file string) (*Config, error) {
-	fmt.Printf("Loading config from %s/%s\n", path, file)
 	conf := new(Config)
 	_, err := os.Stat(filepath.Join(path, file))
 	if err != nil {


### PR DESCRIPTION
- Eliminated unused `fmt.Printf` debug output for cleaner code.
- Ensured no side effects or unnecessary console output in configuration loading logic.