### PR TITLE
Added unit test for i18n provider initialization

### DIFF
--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Winni Neessen <wn@neessen.dev>
+//
+// SPDX-License-Identifier: MIT
+
+package i18n
+
+import "testing"
+
+func TestNew(t *testing.T) {
+	t.Run("new i18n provider with empty locale string succeeds", func(t *testing.T) {
+		provider, err := New("")
+		if err != nil {
+			t.Fatalf("failed to create i18n provider: %s", err)
+		}
+		if provider == nil {
+			t.Fatal("expected i18n provider to be non-nil")
+		}
+	})
+}


### PR DESCRIPTION
- Introduced `TestNew` to validate creation of i18n provider with an empty locale string.
- Ensured the test checks for non-nil provider and proper error handling on initialization.
- Included SPDX license header for compliance.