### PR TITLE
Added example geolocation file to AUR package

### DIFF
--- a/contrib/aur/PKGBUILD
+++ b/contrib/aur/PKGBUILD
@@ -53,9 +53,11 @@ package() {
     install -Dm755 "build/${pkgname}" \
         "${pkgdir}/usr/bin/${pkgname}"
 
-    # example config
+    # example files
     install -Dm644 "etc/config.toml" \
         "${pkgdir}/usr/share/${pkgname}/config.toml"
+    install -Dm644 "etc/geolocation" \
+        "${pkgdir}/usr/share/${pkgname}/geolocation"
 
     # documentation
     install -Dm644 "README.md" \

--- a/contrib/aur/geolocation
+++ b/contrib/aur/geolocation
@@ -1,0 +1,9 @@
+## Example file for the geolocation_file geobus provider
+## This provider is based on a simple file containing a <latitude>,<longitude> pair
+## pointing towards the desired location.
+##
+## The geolocation file must be placed in the waybar-weather config directory:
+## ~/.config/waybar-weather/geolocation
+##
+## The following coordinates point towards Apple Park in Cupertino, CA
+37.332806,-122.005371

--- a/contrib/aur/waybar-weather_install.sh
+++ b/contrib/aur/waybar-weather_install.sh
@@ -4,10 +4,10 @@ post_install() {
     echo "The documentation can be found at:"
     echo "    /usr/share/doc/waybar-weather/README.md"
     echo
-    echo "An example configuration has been installed to:"
-    echo "    /usr/share/waybar-weather/config.toml"
-    echo "To use it, copy the file to:"
-    echo "    ~/.config/waybar-weather/config.toml"
+    echo "Example config files are located at:"
+    echo "    /usr/share/waybar-weather/"
+    echo "To use them, copy the desired files to:"
+    echo "    ~/.config/waybar-weather/"
     echo
     echo "The waybar-weather binary requires the 'cap_net_admin' capability."
     echo "This capability has been set automatically."


### PR DESCRIPTION
- Included `geolocation` example file pointing to Apple Park, Cupertino in package example files.
- Updated `PKGBUILD` to install the new example geolocation file.
- Adjusted installation script to reference multiple example files in `/usr/share/waybar-weather/`.

This PR is related to #93.