### PR TITLE
Renamed `geolocation` example file in AUR package

### DIFF
--- a/etc/geolocation
+++ b/etc/geolocation
@@ -1,3 +1,7 @@
+## SPDX-FileCopyrightText: Winni Neessen <wn@neessen.dev>
+##
+## SPDX-License-Identifier: MIT
+##
 ## Example file for the geolocation_file geobus provider
 ## This provider is based on a simple file containing a <latitude>,<longitude> pair
 ## pointing towards the desired location.


### PR DESCRIPTION
- Renamed `geolocation` example file for better alignment with naming conventions.
- Updated AUR package to reflect the file rename.