### PR TITLE
Add NixOS wrapper for waybar-weather cap_net_admin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
@@ -34,7 +35,10 @@
           pname = "waybar-weather";
           inherit version;
 
-          srcs = [ binSrc sourceSrc ];
+          srcs = [
+            binSrc
+            sourceSrc
+          ];
           sourceRoot = ".";
 
           unpackPhase = ''
@@ -87,6 +91,21 @@
           };
         };
       };
+
+      # To set the "cap_net_admin" capability on NixOS, we need to use NixOS
+      # security.wrappers mechanism. It will wrap the binary into
+      # /run/wrappers/bin/waybar-weather, which has the "cap_net_admin" capability
+      # set.
+      nixosModules.default =
+        { pkgs, ... }:
+        {
+          security.wrappers.waybar-weather = {
+            source = "${self.packages.${pkgs.system}.waybar-weather}/bin/waybar-weather";
+            capabilities = "cap_net_admin+ep";
+            owner = "root";
+            group = "root";
+          };
+        };
 
       devShells.${system}.default = pkgs.mkShell {
         packages = [ self.packages.${system}.waybar-weather ];


### PR DESCRIPTION
- Add a NixOS security.wrappers entry to apply cap_net_admin+ep to the waybar-weather binary
- Update the waybar-weather derivation to list binSrc and sourceSrc separately in a multi-line srcs attribute for readability